### PR TITLE
Fix bug that the inventory may be cleared when reducing the size.

### DIFF
--- a/Custom EnderChest/src/net/craftersland/customenderchest/storage/MysqlStorage.java
+++ b/Custom EnderChest/src/net/craftersland/customenderchest/storage/MysqlStorage.java
@@ -296,11 +296,13 @@ public class MysqlStorage implements StorageInterface {
 			try {
 				ItemStack[] items = enderchest.getModdedSerializer().fromBase64(rawData);
 				Inventory inv = Bukkit.getServer().createInventory(null, chestSize);
-				if (chestSize > items.length) {
+				if (chestSize >= items.length) {
 					inv.setContents(items);
 				} else {
 					for (int i=0; i<chestSize; i++) {
-						inv.addItem(items[i]);
+						if (items[i] != null) {
+							inv.addItem(items[i]);
+						}
 					}
 				}
 				


### PR DESCRIPTION
This PR fixes the following issue:

# Prerequisites
- use MySQL storage
- enable modded NBT-data support

# Reproduction steps
1. put any number of items in a level 1+ ender chest
2. restart the server (to clear any caches)
3. reduce the ender chest size (to level 0 or any other value smaller than the previously set)
4. join with the affected account and open the ender chest

# Expected result
The players items should be reordered / stacked to fit inside the now smaller inventory.

# Actual result
An exception is thrown and the players inventory is cleared:
```
[14:45:19] [Craft Scheduler Thread - 193/WARN]: java.lang.IllegalArgumentException: Item cannot be null
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.apache.commons.lang.Validate.noNullElements(Validate.java:364)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory.addItem(CraftInventory.java:287)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.storage.MysqlStorage.decodeInventory(MysqlStorage.java:303)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.storage.MysqlStorage.loadEnderChest(MysqlStorage.java:264)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.DataHandler.loadPlayerFromStorage(DataHandler.java:65)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.PlayerHandler$1.run(PlayerHandler.java:54)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.bukkit.craftbukkit.v1_15_R1.scheduler.CraftTask.run(CraftTask.java:84)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.bukkit.craftbukkit.v1_15_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at java.base/java.lang.Thread.run(Thread.java:834)
[14:45:19] [Craft Scheduler Thread - 193/ERROR]: [CustomEnderChest] Failed to decode inventory for Player! Error: Length of Base64 encoded input string is not a multiple of 4.
[14:45:19] [Craft Scheduler Thread - 193/WARN]: java.lang.IllegalArgumentException: Length of Base64 encoded input string is not a multiple of 4.
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder.decode(Base64Coder.java:267)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder.decodeLines(Base64Coder.java:218)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.utils.EncodingUtil.fromBase64(EncodingUtil.java:37)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.storage.MysqlStorage.decodeInventory(MysqlStorage.java:311)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.storage.MysqlStorage.loadEnderChest(MysqlStorage.java:264)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.DataHandler.loadPlayerFromStorage(DataHandler.java:65)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at net.craftersland.customenderchest.PlayerHandler$1.run(PlayerHandler.java:54)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.bukkit.craftbukkit.v1_15_R1.scheduler.CraftTask.run(CraftTask.java:84)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at org.bukkit.craftbukkit.v1_15_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[14:45:19] [Craft Scheduler Thread - 193/WARN]: at java.base/java.lang.Thread.run(Thread.java:834)
```